### PR TITLE
[codex] Add Uptime Kuma archiver heartbeat

### DIFF
--- a/.github/workflows/sepa-precios-archiver.yml
+++ b/.github/workflows/sepa-precios-archiver.yml
@@ -35,3 +35,10 @@ jobs:
           cd sepa
           bun install --frozen-lockfile --production --linker=isolated
           bun archiver.ts
+
+      - name: Notify Uptime Kuma
+        env:
+          UPTIME_KUMA_PUSH_URL: ${{ secrets.UPTIME_KUMA_PUSH_URL }}
+        run: |
+          curl --fail --silent --show-error --retry 3 \
+            "$UPTIME_KUMA_PUSH_URL"


### PR DESCRIPTION
## What changed

- Adds a post-success heartbeat to the SEPA archiver workflow.
- Reads the private Uptime Kuma push URL from the `UPTIME_KUMA_PUSH_URL` Actions secret.
- Retries transient heartbeat delivery failures three times.

## Why

The archiver runs every three hours, but metadata commits only occur when upstream data changes. A push heartbeat tracks successful archive runs without treating unchanged source data as a failure.

## Validation

- `git diff --check`
- Confirmed the Actions secret is configured in `catdevnull/preciazo`.
